### PR TITLE
Some refactorings to ease extension of the collector framework through subclassing

### DIFF
--- a/EventRecorder/EREventAnnouncement.class.st
+++ b/EventRecorder/EREventAnnouncement.class.st
@@ -23,7 +23,9 @@ Class {
 	#name : #EREventAnnouncement,
 	#superclass : #Announcement,
 	#instVars : [
-		'dictionary'
+		'dictionary',
+		'xp',
+		'task'
 	],
 	#category : #'EventRecorder-Announcements'
 }

--- a/EventRecorder/EREventAnnouncement.class.st
+++ b/EventRecorder/EREventAnnouncement.class.st
@@ -23,9 +23,7 @@ Class {
 	#name : #EREventAnnouncement,
 	#superclass : #Announcement,
 	#instVars : [
-		'dictionary',
-		'xp',
-		'task'
+		'dictionary'
 	],
 	#category : #'EventRecorder-Announcements'
 }

--- a/EventRecorder/EREventBundle.class.st
+++ b/EventRecorder/EREventBundle.class.st
@@ -11,7 +11,9 @@ Class {
 	#instVars : [
 		'url',
 		'category',
-		'data'
+		'data',
+		'xp',
+		'task'
 	],
 	#category : #'EventRecorder-Support'
 }

--- a/EventRecorder/EREventBundle.class.st
+++ b/EventRecorder/EREventBundle.class.st
@@ -11,9 +11,7 @@ Class {
 	#instVars : [
 		'url',
 		'category',
-		'data',
-		'xp',
-		'task'
+		'data'
 	],
 	#category : #'EventRecorder-Support'
 }

--- a/EventRecorder/EREventBundle.class.st
+++ b/EventRecorder/EREventBundle.class.st
@@ -48,6 +48,12 @@ EREventBundle >> entity [
 	^ ZnByteArrayEntity bytes: self data
 ]
 
+{ #category : #visitor }
+EREventBundle >> newMultiBundle [
+
+	^ EREventMultiBundle new
+]
+
 { #category : #accessing }
 EREventBundle >> url [
 	^ url

--- a/EventRecorder/EREventCollector.class.st
+++ b/EventRecorder/EREventCollector.class.st
@@ -47,9 +47,7 @@ Class {
 		'category',
 		'recordedEvents',
 		'registry',
-		'updateAnnouncementBlock',
-		'xp',
-		'task'
+		'updateAnnouncementBlock'
 	],
 	#category : #'EventRecorder-Core'
 }

--- a/EventRecorder/EREventCollector.class.st
+++ b/EventRecorder/EREventCollector.class.st
@@ -149,6 +149,23 @@ EREventCollector >> newAnnouncementForPacking [
 	^ announcement
 ]
 
+{ #category : #packing }
+EREventCollector >> newBundle [
+
+	^ EREventBundle new
+]
+
+{ #category : #packing }
+EREventCollector >> newBundleForPacking [
+
+	| bundle |
+	bundle := self newBundle.
+	bundle
+		url: self url;
+		category: self category.
+	^bundle
+]
+
 { #category : #accessing }
 EREventCollector >> occupant: anObject [ 
 	"anObject sends me data. I weakly keeps anObject and once it is released, I can be removed from GTEventRecorder object."

--- a/EventRecorder/EREventCollector.class.st
+++ b/EventRecorder/EREventCollector.class.st
@@ -47,7 +47,9 @@ Class {
 		'category',
 		'recordedEvents',
 		'registry',
-		'updateAnnouncementBlock'
+		'updateAnnouncementBlock',
+		'xp',
+		'task'
 	],
 	#category : #'EventRecorder-Core'
 }
@@ -131,6 +133,20 @@ EREventCollector >> isLiberated [
 EREventCollector >> liberate [
 	"Liberate me from the occupant so I can be removed from GTEventRecorder object in the next delivery cycle."
 	^ self registry liberate.
+]
+
+{ #category : #packing }
+EREventCollector >> newAnnouncement [
+	^ EREventAnnouncement new
+]
+
+{ #category : #packing }
+EREventCollector >> newAnnouncementForPacking [
+
+	| announcement |
+	announcement := self newAnnouncement.
+	announcement category: self category.
+	^ announcement
 ]
 
 { #category : #accessing }

--- a/EventRecorder/EREventDelivery.class.st
+++ b/EventRecorder/EREventDelivery.class.st
@@ -22,7 +22,8 @@ Class {
 		'permission',
 		'recorder',
 		'queue',
-		'preSuspendingAction'
+		'preSuspendingAction',
+		'standardDuration'
 	],
 	#category : #'EventRecorder-Support'
 }
@@ -112,7 +113,8 @@ EREventDelivery >> initialize [
 	super initialize.
 	mutex := Mutex new.
 	queue := WaitfreeQueue new.
-	permission := true
+	permission := true.
+	standardDuration := 20 minutes
 ]
 
 { #category : #initialization }
@@ -222,7 +224,13 @@ EREventDelivery >> size [
 
 { #category : #accessing }
 EREventDelivery >> standardDuration [
-	^ 20 minutes
+	^ standardDuration ifNil:[standardDuration := self class defaultStandardDuration]
+]
+
+{ #category : #accessing }
+EREventDelivery >> standardDuration: aDuration [
+
+	standardDuration := aDuration
 ]
 
 { #category : #deactivation }

--- a/EventRecorder/EREventDelivery.class.st
+++ b/EventRecorder/EREventDelivery.class.st
@@ -28,6 +28,11 @@ Class {
 	#category : #'EventRecorder-Support'
 }
 
+{ #category : #defaults }
+EREventDelivery class >> defaultStandardDuration [
+	^20 minutes
+]
+
 { #category : #activation }
 EREventDelivery >> activate [
 	"Initialize a delivery process."

--- a/EventRecorder/EREventMultiBundle.class.st
+++ b/EventRecorder/EREventMultiBundle.class.st
@@ -49,12 +49,22 @@ EREventMultiBundle >> entity [
 ]
 
 { #category : #private }
-EREventMultiBundle >> updateEntity: aZnMultiPartFormDataEntity [ 
+EREventMultiBundle >> updateEntity: aZnMultiPartFormDataEntity [
+
 	bundles ifNil: [ ^ self ].
-	self bundles do: [ :eachEventBundle |
-		aZnMultiPartFormDataEntity 
-			addPart: (ZnMimePart fieldName: 'category' value: eachEventBundle category);
-			addPart: (ZnMimePart fieldName: 'data' entity: eachEventBundle entity) ]
+	self bundles do: [ :eachEventBundle | 
+		self
+			updateEntity: aZnMultiPartFormDataEntity
+			forSingleBundle: eachEventBundle ]
+]
+
+{ #category : #private }
+EREventMultiBundle >> updateEntity: aZnMultiPartFormDataEntity forSingleBundle: aSingleBundle [
+
+	aZnMultiPartFormDataEntity
+		addPart:
+			(ZnMimePart fieldName: 'category' value: aSingleBundle category);
+		addPart: (ZnMimePart fieldName: 'data' entity: aSingleBundle entity)
 ]
 
 { #category : #accessing }

--- a/EventRecorder/EREventMultiBundleFactory.class.st
+++ b/EventRecorder/EREventMultiBundleFactory.class.st
@@ -48,6 +48,6 @@ EREventMultiBundleFactory >> visitSingleBundle: aSingleBundle [
 	| multiBundle |
 	multiBundle := multiBundles 
 							at: aSingleBundle url 
-							ifAbsentPut: [ EREventMultiBundle new url: aSingleBundle url; yourself ].
+							ifAbsentPut: [ aSingleBundle newMultiBundle url: aSingleBundle url; yourself ].
 	multiBundle add: aSingleBundle
 ]

--- a/EventRecorder/EREventPacking.class.st
+++ b/EventRecorder/EREventPacking.class.st
@@ -64,12 +64,11 @@ EREventPacking >> newAnnouncementFor: aGTEventCollector [
 ]
 
 { #category : #packing }
-EREventPacking >> pack: aGTEventCollector [
-	^ EREventBundle new
-			url: aGTEventCollector url;
-			category: aGTEventCollector category;
-			data: (self packCollector: aGTEventCollector);
-			yourself
+EREventPacking >> pack: anEREventCollector [
+
+	^ anEREventCollector newBundleForPacking
+		  data: (self packCollector: anEREventCollector);
+		  yourself
 ]
 
 { #category : #private }

--- a/EventRecorder/EREventPacking.class.st
+++ b/EventRecorder/EREventPacking.class.st
@@ -29,6 +29,25 @@ EREventPacking class >> ston [
 ]
 
 { #category : #private }
+EREventPacking >> buildAnnouncementFor: anEREventCollector [
+
+	| announcement |
+	announcement := anEREventCollector newAnnouncementForPacking.
+	announcement
+		data: (self serialize: anEREventCollector bundle);
+		serializedBy: self class name;
+		eventRecorderVersion: self version;
+		timestamp: DateAndTime now;
+		imageHash: SmalltalkImage current imagePath hash;
+		imageVersion: SystemVersion current version;
+		latestUpdate: SystemVersion current commitHash;
+		computerUUID: GlobalIdentifier uniqueInstance computerUUID asString;
+		sessionUUID: SmalltalkImage current session id asString;
+		sessionCreationTime: SmalltalkImage current session creationTime.
+	^ anEREventCollector updateAnnouncement: announcement
+]
+
+{ #category : #private }
 EREventPacking >> materialize: aByteArray [
 	^ self subclassResponsibility
 ]
@@ -38,19 +57,10 @@ EREventPacking >> migrations: anObject [
 	"Ignore by default. Subclasses can overwrite it."
 ]
 
-{ #category : #'instance creation' }
-EREventPacking >> newAnnouncement [
-	^ EREventAnnouncement new
-]
-
 { #category : #private }
 EREventPacking >> newAnnouncementFor: aGTEventCollector [
-	| announcement |
-	announcement := self 
-		updateAnnouncement: self newAnnouncement 
-		for: aGTEventCollector.
-	aGTEventCollector updateAnnouncement: announcement.
-	^ announcement
+
+	^self buildAnnouncementFor: aGTEventCollector
 ]
 
 { #category : #packing }
@@ -81,23 +91,6 @@ EREventPacking >> technologyName [
 { #category : #packing }
 EREventPacking >> unpack: aByteArray [
 	^ self materialize: aByteArray
-]
-
-{ #category : #private }
-EREventPacking >> updateAnnouncement: aGTEventAnnouncement for: aGTEventCollector [
-	^ aGTEventAnnouncement
-			data: (self serialize: aGTEventCollector bundle);
-			category: aGTEventCollector category;
-			serializedBy: self class name;
-			eventRecorderVersion: self version;
-			timestamp: DateAndTime now;
-			imageHash: SmalltalkImage current imagePath hash;
-			imageVersion: SystemVersion current version;
-			latestUpdate: SystemVersion current commitHash;
-			computerUUID: GlobalIdentifier uniqueInstance computerUUID asString;
-			sessionUUID: SmalltalkImage current session id asString;
-			sessionCreationTime: SmalltalkImage current session creationTime;
-			yourself
 ]
 
 { #category : #accessing }

--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ Migration steps done:
 
 ## Installation
 
+
 ~~~
 Metacello new 
   baseline: 'EventRecorder'; 
-  repository: 'github://Pharo-XP-Tools/EventRecorder/';
-  load: #('Core').
+  repository: 'github://pharo-contributions/EventRecorder/';
+  load.
 ~~~

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Migration steps done:
 
 ## Installation
 
-
+Load into Pharo 8 and 9:
 ~~~
 Metacello new 
   baseline: 'EventRecorder'; 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ Load in a Pharo 8 with:
 ~~~
 Metacello new 
   baseline: 'EventRecorder'; 
-  repository: 'github://pharo-contributions/EventRecorder/';
+  repository: 'github://Pharo-XP-Tools/EventRecorder/';
   load.
 ~~~

--- a/README.md
+++ b/README.md
@@ -22,10 +22,9 @@ Migration steps done:
 
 ## Installation
 
-Load in a Pharo 8 with:
 ~~~
 Metacello new 
   baseline: 'EventRecorder'; 
   repository: 'github://Pharo-XP-Tools/EventRecorder/';
-  load.
+  load: #('Core').
 ~~~


### PR DESCRIPTION
Just for information as it might be of interest.
Basically, it justs moves the responsibility of creating and configuring some objects critical to packing before sending them into the network.

It eases:
- extending the packed data with new meta-data by subclassing bundles, events and announcements
- extending the packed data server-side reception and serialization by subclassing handlers and delegates